### PR TITLE
[PIO-46] Fix readlink with -f option not working on BSD based systems

### DIFF
--- a/bin/pio
+++ b/bin/pio
@@ -32,7 +32,24 @@ search() {
   echo ${i}
 }
 
-export PIO_HOME="$(cd $(dirname $(readlink -f $0))/..; pwd)"
+PIO_FILE=$(readlink -f $0 2>/dev/null)
+if [ $? = 0 ] ; then 
+  export PIO_HOME="$(cd $(dirname $PIO_FILE)/..; pwd)"
+else
+  TARGET_FILE="$0"
+  cd "$(dirname "$TARGET_FILE")"
+  TARGET_FILE=$(basename "$TARGET_FILE")
+
+  while [ -L "$TARGET_FILE" ]
+  do
+    TARGET_FILE=$(readlink "$TARGET_FILE")
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  export PIO_HOME="$(cd $(dirname "$TARGET_FILE")/..; pwd -P)"
+fi
+
 
 export PIO_CONF_DIR="${PIO_HOME}/conf"
 


### PR DESCRIPTION
起動スクリプト内の readlink -f がMacではエラーとなるため修正。